### PR TITLE
Improve security for Docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ This is available as part of the Ballerina Tools distribution.
 ## Building From Source
 > Docker is required to build and enable Ballerina Container Support. To install Docker, follow the instructions on the [Docker Engine Installation Guide](https://docs.docker.com/engine/installation/). Make sure `docker` commands can be run without root/admin privileges.
 
-####Important 
-> **The base Ballerina Docker image has to be built before building on running Ballerina Container Support. To do this follow the instructions in the [Ballerina Base Image README](ballerina-base-image/README.md) and build `ballerina-pkg:latest` Docker image.**
-
 Navigate to the source root and execute the following command.
 
 ```bash

--- a/ballerina-base-image/Dockerfile
+++ b/ballerina-base-image/Dockerfile
@@ -15,30 +15,34 @@
 # -----------------------------------------------------------------------
 
 FROM openjdk:jre-alpine
-MAINTAINER dev@wso2.org
+MAINTAINER tryballerina@gmail.com
 
-ARG BAL_DIST
-
-# Insall Bash
-RUN mkdir -p /ballerina && apk add --update bash && rm -rf /var/cache/apk/*
+ARG BALLERINA_DIST
 
 # Add Ballerina
-COPY ${BAL_DIST} /ballerina/
+COPY ${BALLERINA_DIST} /root/
 COPY scripts/cmd.sh /usr/bin/cmd.sh
 
-
-RUN chmod +x /usr/bin/cmd.sh && \
-    unzip /ballerina/${BAL_DIST} -d /ballerina/ && \
-    rm -rf /ballerina/${BAL_DIST} > /dev/null 2>&1 && \
+# Create folders, unzip distribution, create users, & set permissions.
+RUN mkdir -p /ballerina && \
+    apk add --update bash && \
+    rm -rf /var/cache/apk/* && \
+    chmod +x /usr/bin/cmd.sh && \
+    unzip /root/${BALLERINA_DIST} -d /ballerina/ && \
+    rm -rf /root/${BALLERINA_DIST} > /dev/null 2>&1 && \
     mv /ballerina/ballerina* /ballerina/dist && \
     ln -s /ballerina/dist/bin/ballerina /usr/bin/ballerina && \
     ln -s /ballerina/dist/bin/ballerinaserver /usr/bin/ballerinaserver && \
-    mkdir -p /ballerina/dist/logs
+    mkdir -p /ballerina/dist/logs && \
+    addgroup ballerina && \
+    adduser -S -s /bin/bash -g 'buser' -G ballerina -D buser && \
+    chown -R buser:ballerina /ballerina && \
+    chown buser:ballerina /usr/bin/cmd.sh
 
 ENV BALLERINA_HOME=/ballerina/dist
 WORKDIR /ballerina/dist
+USER buser
+
 EXPOSE 9090
 
-# Ballerina Runner
 ENTRYPOINT ["/usr/bin/cmd.sh"]
-# TODO: Reduce image size (~50MB from copying dist over network)

--- a/ballerina-base-image/build.sh
+++ b/ballerina-base-image/build.sh
@@ -66,7 +66,10 @@ fi
 echo "Building Ballerina Base Docker image $image_name..."
 cp $bal_dist_file .
 bal_dist_file_name=$(basename $bal_dist_file)
-docker build --no-cache=true --build-arg BAL_DIST=${bal_dist_file_name} -t $image_name .
+
+docker build --no-cache=true \
+             --build-arg BALLERINA_DIST=${bal_dist_file_name} \
+             -t $image_name .
 
 echo "Cleaning..."
 docker images | grep "<none>" | awk '{print $3}' | xargs docker rmi -f > /dev/null 2>&1

--- a/src/main/resources/docker/image/Dockerfile
+++ b/src/main/resources/docker/image/Dockerfile
@@ -14,8 +14,8 @@
 # limitations under the License.
 # -----------------------------------------------------------------------
 
-FROM ballerina-pkg:latest
-MAINTAINER dev@wso2.org
+FROM ballerina/ballerina-pkg:0.8.0
+MAINTAINER tryballerina@gmail.com
 
 ARG SVC_MODE=false
 ARG FILE_MODE=false


### PR DESCRIPTION
Change parent Docker image to a publicly available one - Now the base image doesn't have to be built separately