### PR TITLE
Fix docker build issue on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ Docker image myhelloworld:0.1 successfully built.
 Use the following command to execute the archive in a container.
         docker run --name annual_avenue -it myhelloworld:0.1
 ```
-If a remote Docker daemon is available to be used, it can also be specified so the Docker image is created at the remote end.
+If the operating system is Windows or Docker daemon is not available on localhost, specify the Docker host as follows:
 
 ```
-$ ./ballerina docker helloWorld.bmz -H http://127.0.0.1:2375
-Build docker image [helloworld:latest] in docker host [http://127.0.0.1:2375]? (y/n): y
+$ ./ballerina docker helloWorld.bmz -H https://<docker-host>:<docker-port>
+Build docker image [helloworld:latest] in docker host [https://<docker-host>:<docker-port>]? (y/n): y
 
 Docker image helloworld:latest successfully built.
 

--- a/src/main/java/org/ballerinalang/containers/docker/cmd/DockerCmd.java
+++ b/src/main/java/org/ballerinalang/containers/docker/cmd/DockerCmd.java
@@ -20,6 +20,7 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.ballerinalang.containers.Constants;
 import org.ballerinalang.containers.docker.BallerinaDockerClient;
 import org.ballerinalang.containers.docker.cmd.validator.DockerHostValidator;
@@ -49,6 +50,8 @@ public class DockerCmd implements BLauncherCmd {
     private static final String BALLERINA_MAIN_PACKAGE_EXTENSION = "bmz";
     private static final String BALLERINA_SERVICE_PACKAGE_EXTENSION = "bsz";
     private static final String DEFAULT_DOCKER_HOST = "localhost";
+    private static final String OS_NAME = "os.name";
+    private static final String OS_NAME_WINDOWS = "Windows";
 
     private static PrintStream outStream = System.err;
     private JCommander parentCmdParser = null;
@@ -107,6 +110,13 @@ public class DockerCmd implements BLauncherCmd {
         String packageCompletePath = packagePathNames.get(0);
         if (!Files.exists(Paths.get(packageCompletePath))) {
             throw LauncherUtils.createUsageException("cannot find ballerina package: " + packageCompletePath);
+        }
+
+        if (StringUtils.isEmpty(dockerHost)) {
+            String osName = System.getProperty(OS_NAME);
+            if (osName != null && osName.contains(OS_NAME_WINDOWS)) {
+                throw LauncherUtils.createUsageException("docker host parameter is required");
+            }
         }
 
         String packageName = FilenameUtils.getBaseName(packageCompletePath);

--- a/src/main/java/org/ballerinalang/containers/docker/impl/DefaultBallerinaDockerClient.java
+++ b/src/main/java/org/ballerinalang/containers/docker/impl/DefaultBallerinaDockerClient.java
@@ -52,12 +52,13 @@ import java.util.concurrent.CountDownLatch;
 /**
  * Default implementation of the {@link BallerinaDockerClient}.
  */
-public class DefaultBallerinaDockerClient implements BallerinaDockerClient {
+public final class DefaultBallerinaDockerClient implements BallerinaDockerClient {
 
     private static final String BALLERINA_VERSION_SYSTEM_PROP = "ballerina.version";
     private static final String TMPDIR_SYSTEM_PROP = "java.io.tmpdir";
+    private static final String DOCKER_CLIENT_TMPDIR_SYSTEM_PROP = "tmp.dir";
     private static final String PATH_FILES = "files";
-    private static final String PATH_DOCKER_IMAGE_ROOT = "/docker/image";
+    private static final String PATH_DOCKER_IMAGE_ROOT = "/docker/image/";
     private static final String PATH_DOCKERFILE_NAME = "Dockerfile";
     private static final String PATH_TEMP_DOCKERFILE_CONTEXT_PREFIX = "ballerina-docker-";
     private static final String PATH_BAL_FILE_EXT = ".bal";
@@ -317,6 +318,8 @@ public class DefaultBallerinaDockerClient implements BallerinaDockerClient {
             if (!tmpDirFile.exists() && !tmpDirFile.mkdirs()) {
                 throw new BallerinaDockerClientException("Couldn't create temporary directory: " + tmpDirLocation);
             }
+            // Set Fabric8 docker-client temp directory since the default "/tmp" does not work on Windows
+            System.setProperty(DOCKER_CLIENT_TMPDIR_SYSTEM_PROP, tmpDirLocation);
         }
         
         if (ballerinaVersion == null) {
@@ -327,8 +330,7 @@ public class DefaultBallerinaDockerClient implements BallerinaDockerClient {
         String tempDirName = PATH_TEMP_DOCKERFILE_CONTEXT_PREFIX + String.valueOf(Instant.now().getEpochSecond());
         Path tmpDir = Files.createTempDirectory(tempDirName);
         Files.createDirectory(Paths.get(tmpDir.toString() + File.separator + PATH_FILES));
-        InputStream in = getClass().getResourceAsStream(PATH_DOCKER_IMAGE_ROOT + File.separator +
-                PATH_DOCKERFILE_NAME);
+        InputStream in = getClass().getResourceAsStream(PATH_DOCKER_IMAGE_ROOT + PATH_DOCKERFILE_NAME);
 
         Files.copy(in,
                 Paths.get(tmpDir.toString() + File.separator + PATH_DOCKERFILE_NAME),


### PR DESCRIPTION
Currently ballerina docker command seems to be failing on Windows due to three reasons:

1. Resource path /docker/image/Dockerfile is being constructed with Windows file separator
2. Fabric8 docker-client defaults its temporary directory to "/tmp" [1] and that is being invalid on Windows
3. Default docker host is being set to UNIX Docker socket and it does not work on Windows

This pull request fixes these issues by changing the resource path of the Dockerfile template to "/docker/image/Dockerfile", setting "tmp.dir" to dynamically generated temporary directory and adding a validation to check whether the user has provided docker host parameter if the OS is Windows.

Sample usage on Windows:

```
ballerina docker echoService.bsz
ballerina: docker host parameter is required
```

```
ballerina docker -H https://192.168.64.100:2376 echoService.bsz
```

[1] https://github.com/fabric8io/docker-client/blob/v1.2.1/client/src/main/java/io/fabric8/docker/client/impl/BaseImageOperation.java#L27