### PR TITLE
Migrate base image to 0.92/0.93 runtime.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ mvn clean install
 This will create a fat JAR file with the dependencies included, inside the `target` folder.
 
 ## Usage
-Add the `ballerina-container-support-0.8.1.jar` file to `bre/lib/` folder in the Ballerina distribution.
+Add the `ballerina-container-support-0.93.jar` file to `bre/lib/` folder in the Ballerina distribution.
 
 ### `ballerina docker` Command Line Usage
 ```
-create docker images for Ballerina program archives
+create docker images for Ballerina program files
 
 Usage:
 ballerina docker <package-name> [--tag | -t <image-name>] [--host | -H <docker-hostURL>] --help | -h --yes | -y
@@ -29,12 +29,12 @@ Flags:
   --yes, -y     assume yes for prompts
   --host, -H    docker Host. http://<ip-address>:<port>
 ```
-The `docker` command will detect the Ballerina archive type (main vs service) from the archive file extension provided. 
+The `docker` command will detect the Ballerina file type (main vs service) from the file extension provided.
 
-To create a Docker image from a Ballerina package, simply provide the package name as an argument.
+To create a Docker image from a Ballerina file, simply provide the file name as an argument.
 
 ```
-$ ./ballerina docker helloWorld.bmz
+$ ./ballerina docker helloWorld.bal
 Build docker image [helloworld:latest] in docker host [localhost]? (y/n): y
 
 Docker image helloworld:latest successfully built.
@@ -46,7 +46,7 @@ Use the following command to execute the archive in a container.
 Creating a Docker image for a Ballerina Service.
 
 ```
-$ ./ballerina docker helloWorldService.bsz
+$ ./ballerina docker helloWorldService.balx
 Build docker image [helloworldservice:latest] in docker host [localhost]? (y/n): y
 
 Docker image helloworldservice:latest successfully built.
@@ -70,7 +70,7 @@ Make requests using the format [curl -X <http-method> http://localhost:44558/<se
 You can additionally provide a customized image name.
 
 ```
-$ ./ballerina docker helloWorld.bmz -t myhelloworld:0.1
+$ ./ballerina docker helloWorld.bal -t myhelloworld:0.1
 Build docker image [myhelloworld:0.1] in docker host [localhost]? (y/n): y
 
 Docker image myhelloworld:0.1 successfully built.
@@ -81,7 +81,7 @@ Use the following command to execute the archive in a container.
 If the operating system is Windows or Docker daemon is not available on localhost, specify the Docker host as follows:
 
 ```
-$ ./ballerina docker helloWorld.bmz -H https://<docker-host>:<docker-port>
+$ ./ballerina docker helloWorld.bal -H https://<docker-host>:<docker-port>
 Build docker image [helloworld:latest] in docker host [https://<docker-host>:<docker-port>]? (y/n): y
 
 Docker image helloworld:latest successfully built.
@@ -91,25 +91,25 @@ Use the following command to execute the archive in a container.
 ```
 
 # Ballerina Docker Image
-The Docker distribution for Ballerina is available on Docker Hub as `ballerinalang/ballerina`. To run a Ballerina package using the Ballerina Docker image, simply mount the folder containing the package(s) to `/ballerina/files` folder inside the container. 
+The Docker distribution for Ballerina is available on Docker Hub as `ballerinalang/ballerina`. To run a Ballerina package using the Ballerina Docker image, simply mount the folder containing the file to `/ballerina/files` folder inside the container.
 
 ```bash
 # Create a directory and copy the packages needed to be run.
 mkdir -p ~/ballerina/packages/
-cp mypackage.bmz ~/ballerina/packages/
-chmod +r ~/ballerina/packages/mypackage.bmz
+cp mypackage.balx ~/ballerina/packages/
+chmod +r ~/ballerina/packages/mypackage.balx
 
 # Run container with the volume mount
-docker run -v ~/ballerina/packages:/ballerina/files -it ballerinalang/ballerina:0.8.1
+docker run -v ~/ballerina/packages:/ballerina/files -it ballerinalang/ballerina:0.93
 ```
 
-If you are running a Ballerina Service, set the `SVC_MODE` environment variable to `true`. 
+If you are running a Ballerina Service,
 
 ```bash
-cp mysvcpackage.bsz ~/ballerina/packages/
-chmod +r ~/ballerina/packages/mysvcpackage.bsz
+cp mysvcpackage.balx ~/ballerina/packages/
+chmod +r ~/ballerina/packages/mysvcpackage.balx
 
-docker run -v /tmp/testb:/ballerina/files -e "SVC_MODE=true" -p 9090:9090 -it ballerinalang/ballerina:0.8.1
+docker run -v /tmp/testb:/ballerina/files -p 9090:9090 -it ballerinalang/ballerina:0.93
 ```
 ## License
 Ballerina Container Support is licensed under [Apache License v2](LICENSE).

--- a/ballerina-base-image/Dockerfile
+++ b/ballerina-base-image/Dockerfile
@@ -33,8 +33,7 @@ LABEL org.label-schema.vcs-url="https://github.com/ballerinalang/container-suppo
 LABEL org.label-schema.vcs-ref=$VCS_REF
 LABEL org.label-schema.vendor="WSO2"
 LABEL org.label-schema.version=$BUILD_VERSION
-LABEL org.label-schema.docker.cmd="docker run -v ~/ballerina/packages:/ballerina/files -e 'SVC_MODE=true' -p 9090:9090 -d ballerinalang/ballerina"
-LABEL org.label-schema.docker.params="SVC_MODE=true if packages to be run are Ballerina Services, false if they are Ballerina main programs"
+LABEL org.label-schema.docker.cmd="docker run -v ~/ballerina/packages:/ballerina/files -p 9090:9090 -d ballerinalang/ballerina"
 
 
 # Add Ballerina runtime.
@@ -70,14 +69,8 @@ EXPOSE 9090
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
-# Instructions for derivative images.
-ONBUILD ARG SVC_MODE=false
-ONBUILD ARG FILE_MODE=false
-
 # Force child images to override the crucial labels
 ONBUILD ARG BUILD_DATE
 ONBUILD RUN if [ -z "$BUILD_DATE" ]; then >&2 echo "ERROR: Haven't set mandatory build argument \"BUILD_DATE\". Please set an RFC 3339 Date value."; exit 1; fi
 LABEL org.label-schema.build-date=$BUILD_DATE
 
-ONBUILD ENV SVC_MODE=${SVC_MODE}
-ONBUILD ENV FILE_MODE=${FILE_MODE}

--- a/ballerina-base-image/README.md
+++ b/ballerina-base-image/README.md
@@ -8,20 +8,20 @@ The Docker distribution for Ballerina is available on Docker Hub as `ballerinala
 ```bash
 # Create a directory and copy the packages needed to be run.
 mkdir -p ~/ballerina/packages/
-cp mypackage.bmz ~/ballerina/packages/
-chmod +r ~/ballerina/packages/mypackage.bmz
+cp mypackage.balx ~/ballerina/packages/
+chmod +r ~/ballerina/packages/mypackage.balx
 
 # Run container with the volume mount
 docker run -v ~/ballerina/packages:/ballerina/files -it ballerinalang/ballerina
 ```
 
-If you are running a Ballerina Service, set the `SVC_MODE` environment variable to `true`. 
+If you are running a Ballerina Service,
 
 ```bash
-cp mysvcpackage.bsz ~/ballerina/packages/
-chmod +r ~/ballerina/packages/mysvcpackage.bsz
+cp mysvcpackage.balx ~/ballerina/packages/
+chmod +r ~/ballerina/packages/mysvcpackage.balx
 
-docker run -v /tmp/testb:/ballerina/files -e "SVC_MODE=true" -p 9090:9090 -it ballerinalang/ballerina
+docker run -v /tmp/testb:/ballerina/files -p 9090:9090 -it ballerinalang/ballerina
 ```
 
 ## Building the image
@@ -43,12 +43,10 @@ This base image can be used by child images to pack one or more Ballerina packag
 This base image contains build triggers to make sure that crucial settings are applied in the child images. Because of this, the following values must be set as build arguments when building child images.
 
 ```
-SVC_MODE=[true|false]
-FILE_MODE=[true|false]
 BUILD_DATE=[RFC3339 formatted date]
 ```
 
-Out of these, `BUILD_DATE` is mandatory, as this affects the meta data of the child images. The value should be `RFC 3339` formatted value of the current date and time.
+`BUILD_DATE` is mandatory, as this affects the meta data of the child images. The value should be `RFC 3339` formatted value of the current date and time.
 
 ```
 BUILD_DATE=2017-02-27T09:22:57Z
@@ -68,15 +66,7 @@ FROM ballerinalang/ballerina
 COPY files/* /ballerina/files/
 ```
 
-Notice that the only task the child Dockerfile does is to copy Ballerina packages to the standard location inside the image which is `/ballerina/files`. In this case, the Ballerina package will have to be a Ballerina `main`. For an image that packs a Ballerina Service archive, the Dockerfile would change to something like the following.
-
-```Dockerfile
-FROM ballerinalang/ballerina
-
-ENV SVC_MODE=true
-
-COPY files/* /ballerina/files/
-```
+Notice that the only task the child Dockerfile does is to copy Ballerina packages to the standard location inside the image which is `/ballerina/files`.
 
 ## Updating DockerHub
 

--- a/ballerina-base-image/README.md
+++ b/ballerina-base-image/README.md
@@ -27,11 +27,11 @@ docker run -v /tmp/testb:/ballerina/files -p 9090:9090 -it ballerinalang/balleri
 ## Building the image
 ```bash
 # bash build.sh -d <ballerina-dist> to build ballerina:latest
-cp ~/Downloads/ballerina-0.92.zip .
-bash build.sh -d ballerina-0.92.zip
+cp ~/Downloads/ballerina-0.93.zip .
+bash build.sh -d ballerina-0.93.zip
 
 # Or build without copying the distribution.
-bash build.sh -d ~/Downloads/ballerina-0.92.zip
+bash build.sh -d ~/Downloads/ballerina-0.93.zip
 
 # Show usage
 bash build.sh -h
@@ -77,39 +77,39 @@ After each Ballerina runtime release, the base image in the Public Docker Hub sh
 1. **OPTIONAL:** Copy the official Ballerina Runtime release to the Dockerfile context.
 ```bash
 $ cd ballerinalang/container-support/ballerina-base-image
-$ cp ~/Downloads/ballerina-0.92.zip .
+$ cp ~/Downloads/ballerina-0.93.zip .
 ```
 
 2. Build the Docker image with an organization prefix for `ballerinalang`, and a version tag of the Ballerina runtime release version.
 
 ```bash
-$ bash build.sh -d ~/dev/ballerina/ballerina-0.92.zip -v 0.92 -o ballerinalang
+$ bash build.sh -d ~/dev/ballerina/ballerina-0.93.zip -v 0.93 -o ballerinalang
 ```
 
-3. This will build a Docker image with name `ballerinalang/ballerina:0.92` in the local Docker repository. The `latest` tag for `ballerinalang/ballerina` should now also point to this image now.
+3. This will build a Docker image with name `ballerinalang/ballerina:0.93` in the local Docker repository. The `latest` tag for `ballerinalang/ballerina` should now also point to this image now.
 ```bash
-$ docker tag ballerinalang/ballerina:0.92 ballerinalang/ballerina:latest
+$ docker tag ballerinalang/ballerina:0.93 ballerinalang/ballerina:latest
 ```
 
 4. The same image should also be pushed to `ballerina` organization. For this, re-creating the image is not necessary. Instead, another set of tags can be pointed to the same image.
 ```bash
-$ docker tag ballerinalang/ballerina:0.92 ballerina/ballerina:0.92
-$ docker tag ballerinalang/ballerina:0.92 ballerina/ballerina:latest
+$ docker tag ballerinalang/ballerina:0.93 ballerina/ballerina:0.93
+$ docker tag ballerinalang/ballerina:0.93 ballerina/ballerina:latest
 ```
 
 5. If the Docker images are listed, it should show an output similar to the following. Notice that the `Image ID` column contains the same value for all four tags. This is because they all point to the same AUFS layer.
 ```
 REPOSITORY                                        TAG                                 IMAGE ID            CREATED             SIZE
-ballerinalang/ballerina                           0.92                                4daa1c1f2089        1 minute ago        142MB
+ballerinalang/ballerina                           0.93                                4daa1c1f2089        1 minute ago        142MB
 ballerinalang/ballerina                           latest                              4daa1c1f2089        1 minute ago        142MB
-ballerina/ballerina                               0.92                                4daa1c1f2089        1 minute ago        142MB
+ballerina/ballerina                               0.93                                4daa1c1f2089        1 minute ago        142MB
 ballerina/ballerina                               latest                              4daa1c1f2089        1 minute ago        142MB
 ```
 
 6. Push the above Docker images to the Public Docker Hub. Observe how only the first push command actually pushes any data. The rest of the push commands only push the tag details, since the image is already pushed once.
 ```bash
-$ docker push ballerinalang/ballerina:0.92
+$ docker push ballerinalang/ballerina:0.93
 $ docker push ballerinalang/ballerina:latest
-$ docker push ballerina/ballerina:0.92
+$ docker push ballerina/ballerina:0.93
 $ docker push ballerina/ballerina:latest
 ```

--- a/ballerina-base-image/build.sh
+++ b/ballerina-base-image/build.sh
@@ -20,8 +20,8 @@ function showUsageAndExit() {
     echo
     echo "USAGE: ./build.sh -d <ballerina-distribution> -v <image-version> -o <organization-name>"
     echo
-    echo "Ex: Create a Ballerina Docker image tagged \"ballerina:latest\" with Ballerina 0.8.1 distribution."
-    echo "    ./build.sh -d ballerina-0.8.1.zip"
+    echo "Ex: Create a Ballerina Docker image tagged \"ballerina:latest\" with Ballerina 0.92 distribution."
+    echo "    ./build.sh -d ballerina-0.92.zip"
     echo
 
     exit

--- a/ballerina-base-image/build.sh
+++ b/ballerina-base-image/build.sh
@@ -20,8 +20,8 @@ function showUsageAndExit() {
     echo
     echo "USAGE: ./build.sh -d <ballerina-distribution> -v <image-version> -o <organization-name>"
     echo
-    echo "Ex: Create a Ballerina Docker image tagged \"ballerina:latest\" with Ballerina 0.92 distribution."
-    echo "    ./build.sh -d ballerina-0.92.zip"
+    echo "Ex: Create a Ballerina Docker image tagged \"ballerina:latest\" with Ballerina 0.93 distribution."
+    echo "    ./build.sh -d ballerina-0.93.zip"
     echo
 
     exit

--- a/ballerina-base-image/docker-entrypoint.sh
+++ b/ballerina-base-image/docker-entrypoint.sh
@@ -14,24 +14,12 @@
 # limitations under the License.
 
 function collectArgs() {
-    if [ ! -z "$FILE_MODE" ] && [ "$FILE_MODE" = "true" ]; then
-        # Running single Ballerina files
-        arg_str=$(find /ballerina/files -type f -name "*.bal")
-    elif [ ! -z "$SVC_MODE" ] && [ "$SVC_MODE" = "true" ]; then
-        # Running Ballerina service packages
-        arg_str=$(find /ballerina/files -type f -name "*.bsz")
-    else
-        # Running Ballerina main packages
-        arg_str=$(find /ballerina/files -type f -name "*.bmz")
-    fi
+    # Running Ballerina bal file or compiled balx, balx has priority
+    arg_str=$(find /ballerina/files -type f -name "*.balx" && find /ballerina/files -type f -name "*.bal")
 }
 
 collectArgs
 
-if [ ! -z "$SVC_MODE" ] && [ "$SVC_MODE" = "true" ]; then
-  cmd="ballerina run service"
-else
-  cmd="ballerina run main"
-fi
+cmd="ballerina run"
 
 exec bin/$cmd $arg_str

--- a/ballerina-base-image/docker-entrypoint.sh
+++ b/ballerina-base-image/docker-entrypoint.sh
@@ -15,7 +15,10 @@
 
 function collectArgs() {
     # Running Ballerina bal file or compiled balx, balx has priority
-    arg_str=$(find /ballerina/files -type f -name "*.balx" && find /ballerina/files -type f -name "*.bal")
+    arg_str=$(find /ballerina/files -type f -name "*.balx" -print | head -n 1)
+    if [ -z "$arg_str" ]; then
+        arg_str=$(find /ballerina/files -type f -name "*.bal" -print | head -n 1)
+    fi
 }
 
 collectArgs

--- a/src/main/java/org/ballerinalang/containers/docker/BallerinaDockerClient.java
+++ b/src/main/java/org/ballerinalang/containers/docker/BallerinaDockerClient.java
@@ -40,7 +40,10 @@ public interface BallerinaDockerClient {
      * @throws BallerinaDockerClientException If the input parameters are invalid.
      * @throws IOException                    If specified files cannot be accessed.
      * @throws InterruptedException           If the docker image build process was interrupted.
+     *
+     * @deprecated use {@link #createMainImage(String, String, Path, String, String)} instead.
      */
+    @Deprecated
     String createServiceImage(String packageName, String dockerEnv, List<Path> bPackagePaths,
                               String imageName, String imageVersion)
             throws BallerinaDockerClientException, IOException, InterruptedException;
@@ -74,7 +77,10 @@ public interface BallerinaDockerClient {
      * @throws BallerinaDockerClientException If the input parameters are invalid.
      * @throws IOException                    If specified files cannot be accessed.
      * @throws InterruptedException           If the docker image build process was interrupted.
+     *
+     * @deprecated use {@link #createMainImage(String, String, Path, String, String)} instead.
      */
+    @Deprecated
     String createMainImage(String packageName, String dockerEnv, List<Path> bPackagePaths,
                            String imageName, String imageVersion)
             throws BallerinaDockerClientException, IOException, InterruptedException;

--- a/src/main/java/org/ballerinalang/containers/docker/BallerinaDockerClient.java
+++ b/src/main/java/org/ballerinalang/containers/docker/BallerinaDockerClient.java
@@ -80,6 +80,23 @@ public interface BallerinaDockerClient {
             throws BallerinaDockerClientException, IOException, InterruptedException;
 
     /**
+     * Create a Ballerina Main Docker image from a Ballerina BAL / BALX File.
+     *
+     * @param packageName  The name used to identify the package.
+     * @param dockerEnv    The docker host URL.
+     * @param bPackagePath The paths to package to be packed to the image.
+     * @param imageName    The docker image name to use.
+     * @param imageVersion The docker image version to use.
+     * @return The {@link String} name of the docker image created. Null if the image building process failed.
+     * @throws BallerinaDockerClientException If the input parameters are invalid.
+     * @throws IOException                    If specified files cannot be accessed.
+     * @throws InterruptedException           If the docker image build process was interrupted.
+     */
+    String createMainImage(String packageName, String dockerEnv, Path bPackagePath,
+                           String imageName, String imageVersion)
+            throws BallerinaDockerClientException, IOException, InterruptedException;
+
+    /**
      * Create a Ballerina Main Docker image from a Ballerina configuration.
      *
      * @param mainPackageName The name used to identify the main function to be packed.

--- a/src/main/java/org/ballerinalang/containers/docker/cmd/DockerCmd.java
+++ b/src/main/java/org/ballerinalang/containers/docker/cmd/DockerCmd.java
@@ -47,8 +47,6 @@ import java.util.Locale;
 @Parameters(commandNames = "docker", commandDescription = "create docker images for Ballerina program archives")
 public class DockerCmd implements BLauncherCmd {
 
-    private static final String BALLERINA_MAIN_PACKAGE_EXTENSION = "bmz";
-    private static final String BALLERINA_SERVICE_PACKAGE_EXTENSION = "bsz";
     private static final String BALLERINA_COMPILED_PACKAGE_EXTENSION = "balx";
     private static final String BALLERINA_NON_COMPILED_PACKAGE_EXTENSION = "bal";
     private static final String DEFAULT_DOCKER_HOST = "localhost";
@@ -136,36 +134,6 @@ public class DockerCmd implements BLauncherCmd {
         }
 
         switch (packageExtension) {
-            case BALLERINA_SERVICE_PACKAGE_EXTENSION:
-                try {
-                    String createdImageName = dockerClient.createServiceImage(packageName, dockerHost,
-                            packagePaths, imageName, imageVersion);
-                    if (createdImageName != null) {
-                        printServiceImageSuccessMessage(createdImageName);
-                    } else {
-                        throw LauncherUtils.createUsageException("Docker image build failed for image "
-                                + imageName + ":" + imageVersion + ".");
-                    }
-                } catch (BallerinaDockerClientException | IOException | InterruptedException e) {
-                    throw LauncherUtils.createUsageException(e.getMessage());
-                }
-                break;
-
-            case BALLERINA_MAIN_PACKAGE_EXTENSION:
-                try {
-                    String createdImageName = dockerClient.createMainImage(packageName, dockerHost, packagePaths,
-                            imageName, imageVersion);
-                    if (createdImageName != null) {
-                        printMainImageSuccessMessage(createdImageName);
-                    } else {
-                        throw LauncherUtils.createUsageException("Docker image build failed for image "
-                                + imageName + ":" + imageVersion + ".");
-                    }
-                } catch (BallerinaDockerClientException | IOException | InterruptedException e) {
-                    throw LauncherUtils.createUsageException(e.getMessage());
-                }
-                break;
-
             case BALLERINA_COMPILED_PACKAGE_EXTENSION:
             case BALLERINA_NON_COMPILED_PACKAGE_EXTENSION:
                 if (!(packagePathNames.size() == 1)) {
@@ -245,43 +213,6 @@ public class DockerCmd implements BLauncherCmd {
         } while (--attempts > 0);
 
         return false;
-    }
-
-    /*
-    Print helpful messages for functionality to perform after image build for a Ballerina Service.
-     */
-    private void printServiceImageSuccessMessage(String imageName) {
-        String containerName = Utils.generateContainerName();
-        int portNumber = Utils.generateContainerPort();
-        outStream.println("\nDocker image " + imageName + " successfully built.");
-        outStream.println();
-        outStream.println("Use the following command to start a container.");
-        outStream.println("\tdocker run -p " + portNumber + ":9090 --name " + containerName + " -d " + imageName);
-        outStream.println();
-        outStream.println("Use the following command to inspect the logs.");
-        outStream.println("\tdocker logs " + containerName);
-        outStream.println();
-        outStream.println("Use the following command to retrieve the IP address of the container");
-        outStream.println("\tdocker inspect " + containerName + " | grep IPAddress");
-        outStream.println();
-        outStream.println("Ballerina service will be running on the following ports.");
-        outStream.println("\thttp://localhost:" + portNumber);
-        outStream.println("\thttp://<container-ip>:9090");
-        outStream.println();
-        outStream.println("Make requests using the format [curl -X <http-method> http://localhost:" + portNumber
-                + "/<service-name>]");
-        outStream.println();
-    }
-
-    /*
-    Print helpful messages for functionality to perform after image build for a Ballerina Main program.
-     */
-    private void printMainImageSuccessMessage(String imageName) {
-        String containerName = Utils.generateContainerName();
-        outStream.println("\nDocker image " + imageName + " successfully built.");
-        outStream.println("\nUse the following command to execute the archive in a container.");
-        outStream.println("\tdocker run --name " + containerName + " -it " + imageName);
-        outStream.println();
     }
 
     /*

--- a/src/main/java/org/ballerinalang/containers/docker/impl/DefaultBallerinaDockerClient.java
+++ b/src/main/java/org/ballerinalang/containers/docker/impl/DefaultBallerinaDockerClient.java
@@ -278,7 +278,6 @@ public final class DefaultBallerinaDockerClient implements BallerinaDockerClient
 
         imageName = getImageName(serviceName, imageName, imageVersion);
 
-
         if (!Files.exists(ballerinaConfig)) {
             throw new BallerinaDockerClientException("Cannot find Ballerina file: " + ballerinaConfig.toString());
         }

--- a/src/main/java/org/ballerinalang/containers/docker/impl/DefaultBallerinaDockerClient.java
+++ b/src/main/java/org/ballerinalang/containers/docker/impl/DefaultBallerinaDockerClient.java
@@ -109,6 +109,17 @@ public final class DefaultBallerinaDockerClient implements BallerinaDockerClient
      * {@inheritDoc}
      */
     @Override
+    public String createMainImage(String packageName, String dockerEnv, Path bPackagePath,
+                                  String imageName, String imageVersion)
+            throws BallerinaDockerClientException, IOException, InterruptedException {
+
+        return createImageFromSingleFile(packageName, dockerEnv, bPackagePath, imageName, imageVersion);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String createMainImage(String mainPackageName, String dockerEnv, String ballerinaConfig,
                                   String imageName, String imageVersion)
             throws InterruptedException, BallerinaDockerClientException, IOException {
@@ -250,6 +261,46 @@ public final class DefaultBallerinaDockerClient implements BallerinaDockerClient
         String timestamp = new SimpleDateFormat("yyyy-MM-dd'T'h:m:ssXX").format(new Date());
         String buildArgs = "{\"" + ENV_SVC_MODE + "\":\"" + String.valueOf(isService) + "\", " +
                 "\"" + ENV_FILE_MODE + "\":\"true\", \"BUILD_DATE\":\"" + timestamp + "\"}";
+        buildImage(dockerEnv, imageName, tmpDir, buildArgs);
+
+        // 4. Cleanup
+        cleanupTempDockerfileContext(tmpDir);
+
+        return getImage(imageName, dockerEnv);
+    }
+
+    /**
+     * Create a Docker image from a give Ballerina configuration in bal or balx.
+     */
+    private String createImageFromSingleFile(String serviceName, String dockerEnv, Path ballerinaConfig,
+                                             String imageName, String imageVersion)
+            throws BallerinaDockerClientException, IOException, InterruptedException {
+
+        imageName = getImageName(serviceName, imageName, imageVersion);
+
+
+        if (!Files.exists(ballerinaConfig)) {
+            throw new BallerinaDockerClientException("Cannot find Ballerina file: " + ballerinaConfig.toString());
+        }
+
+        if (!FilenameUtils.getExtension(ballerinaConfig.toString()).equalsIgnoreCase("bal") &&
+                !FilenameUtils.getExtension(ballerinaConfig.toString()).equalsIgnoreCase("balx")) {
+            throw new BallerinaDockerClientException("Invalid Ballerina file. " +
+                    "Ballerina files should be of \"bal\" | \"balx\" type.");
+        }
+
+        // 1. Create a tmp docker context
+        Path tmpDir = prepTempDockerfileContext();
+
+        // 2. Copy a .bal or .balx file inside context/files
+        Files.copy(ballerinaConfig,
+                Paths.get(tmpDir.toString() + File.separator + PATH_FILES + File.separator
+                        + ballerinaConfig.toFile().getName()),
+                StandardCopyOption.REPLACE_EXISTING);
+
+        // 3. Create a docker image from the temp context
+        String timestamp = new SimpleDateFormat("yyyy-MM-dd'T'h:m:ssXX").format(new Date());
+        String buildArgs = "{\"BUILD_DATE\":\"" + timestamp + "\"}";
         buildImage(dockerEnv, imageName, tmpDir, buildArgs);
 
         // 4. Cleanup

--- a/src/test/java/org/ballerinalang/containers/docker/DefaultBallerinaDockerClientSingleFileTest.java
+++ b/src/test/java/org/ballerinalang/containers/docker/DefaultBallerinaDockerClientSingleFileTest.java
@@ -27,6 +27,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -60,12 +62,46 @@ public class DefaultBallerinaDockerClientSingleFileTest {
     }
 
     @Test
+    public void testSuccessfulCreateServiceImageFromFile()
+            throws IOException, InterruptedException, BallerinaDockerClientException {
+
+        String serviceName = "TestService1";
+        String imageName = serviceName.toLowerCase();
+        Path ballerinaConfig = Paths.get(Thread.currentThread().getContextClassLoader().
+                getResource("ballerina/TestService.bal").getPath());
+
+        String result = dockerClient.createMainImage(serviceName, null, ballerinaConfig, null, null);
+        createdImages.add(imageName);
+
+        Assert.assertTrue(
+                (result != null) && (result.equals(imageName + ":" + Constants.IMAGE_VERSION_LATEST)),
+                "Docker image creation failed.");
+    }
+
+    @Test
     public void testSuccessfulCreateFunctionImage()
             throws IOException, InterruptedException, BallerinaDockerClientException {
 
         String serviceName = "TestFunction1";
         String imageName = serviceName.toLowerCase();
         String ballerinaConfig = TestUtils.getTestFunctionAsString();
+
+        String result = dockerClient.createMainImage(serviceName, null, ballerinaConfig, null, null);
+        createdImages.add(imageName);
+
+        Assert.assertTrue(
+                (result != null) && (result.equals(imageName + ":" + Constants.IMAGE_VERSION_LATEST)),
+                "Docker image creation failed.");
+    }
+
+    @Test
+    public void testSuccessfulCreateFunctionImageFromFile()
+            throws IOException, InterruptedException, BallerinaDockerClientException {
+
+        String serviceName = "TestFunction1";
+        String imageName = serviceName.toLowerCase();
+        Path ballerinaConfig = Paths.get(Thread.currentThread().getContextClassLoader().
+                getResource("ballerina/TestFunction.bal").getPath());
 
         String result = dockerClient.createMainImage(serviceName, null, ballerinaConfig, null, null);
         createdImages.add(imageName);

--- a/src/test/java/org/ballerinalang/containers/docker/cmd/DockerCmdTest.java
+++ b/src/test/java/org/ballerinalang/containers/docker/cmd/DockerCmdTest.java
@@ -32,7 +32,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -103,78 +102,6 @@ public class DockerCmdTest {
     @Test
     public void testGetName() {
         Assert.assertEquals(new DockerCmd().getName(), "docker", "The Docker command name should be \"docker\"");
-    }
-
-    @Test
-    public void testExecuteSuccessfulServiceImageCreation()
-            throws NoSuchFieldException, IllegalAccessException, InstantiationException,
-            FileNotFoundException, NoSuchMethodException, InvocationTargetException {
-
-        Class<DockerCmd> cmdClass = DockerCmd.class;
-        DockerCmd dockerCmd = cmdClass.newInstance();
-
-        Field dockerClientField = cmdClass.getDeclaredField("dockerClient");
-        dockerClientField.setAccessible(true);
-        dockerClientField.set(dockerCmd, new TestBallerinaDockerClient());
-
-        Field packageNameField = cmdClass.getDeclaredField("packagePathNames");
-        packageNameField.setAccessible(true);
-        List<Path> packageList = TestUtils.getTestServiceAsPathList();
-        List<String> packageListStr = new ArrayList<>();
-        packageListStr.add(packageList.get(0).toString());
-        packageNameField.set(dockerCmd, packageListStr);
-
-        Field assumeYesField = cmdClass.getDeclaredField("assumeYes");
-        assumeYesField.setAccessible(true);
-        assumeYesField.set(dockerCmd, true);
-
-        ByteArrayOutputStream testOutputStream = new ByteArrayOutputStream();
-        PrintStream testPrintStream = new PrintStream(testOutputStream);
-        Field sysout = cmdClass.getDeclaredField("outStream");
-        sysout.setAccessible(true);
-        sysout.set(dockerCmd, testPrintStream);
-
-        dockerCmd.execute();
-
-        String testResultString = new String(testOutputStream.toByteArray(), StandardCharsets.UTF_8);
-        String[] outLines = testResultString.split("\n");
-        Assert.assertEquals(outLines[1], "Docker image testservice:latest successfully built.");
-    }
-
-    @Test
-    public void testExecuteSuccessfulMainImageCreation()
-            throws NoSuchFieldException, IllegalAccessException, InstantiationException,
-            FileNotFoundException, NoSuchMethodException, InvocationTargetException {
-
-        Class<DockerCmd> cmdClass = DockerCmd.class;
-        DockerCmd dockerCmd = cmdClass.newInstance();
-
-        Field dockerClientField = cmdClass.getDeclaredField("dockerClient");
-        dockerClientField.setAccessible(true);
-        dockerClientField.set(dockerCmd, new TestBallerinaDockerClient());
-
-        Field packageNameField = cmdClass.getDeclaredField("packagePathNames");
-        packageNameField.setAccessible(true);
-        List<Path> packageList = TestUtils.getTestFunctionAsPathList();
-        List<String> packageListStr = new ArrayList<>();
-        packageListStr.add(packageList.get(0).toString());
-        packageNameField.set(dockerCmd, packageListStr);
-
-        Field assumeYesField = cmdClass.getDeclaredField("assumeYes");
-        assumeYesField.setAccessible(true);
-        assumeYesField.set(dockerCmd, true);
-
-        ByteArrayOutputStream testOutputStream = new ByteArrayOutputStream();
-        PrintStream testPrintStream = new PrintStream(testOutputStream);
-        Field sysout = cmdClass.getDeclaredField("outStream");
-        sysout.setAccessible(true);
-        sysout.set(dockerCmd, testPrintStream);
-
-        dockerCmd.execute();
-
-        String testResultString = new String(testOutputStream.toByteArray(), StandardCharsets.UTF_8);
-        String[] outLines = testResultString.split("\n");
-        Assert.assertEquals(outLines[1], "Docker image testfunction:latest successfully built.");
     }
 
     @Test(expectedExceptions = {RuntimeException.class})

--- a/src/test/java/org/ballerinalang/containers/docker/cmd/DockerCmdTest.java
+++ b/src/test/java/org/ballerinalang/containers/docker/cmd/DockerCmdTest.java
@@ -402,6 +402,13 @@ public class DockerCmdTest {
         }
 
         @Override
+        public String createMainImage(String packageName, String dockerEnv, Path bPackagePaths,
+                                      String imageName, String imageVersion)
+                throws BallerinaDockerClientException, IOException, InterruptedException {
+            throw new BallerinaDockerClientException("Not Implemented.");
+        }
+
+        @Override
         public String createMainImage(String mainPackageName, String dockerEnv, String ballerinaConfig,
                                       String imageName, String imageVersion)
                 throws InterruptedException, BallerinaDockerClientException, IOException {


### PR DESCRIPTION
Since .bsz .bmz archives are no longer support after ballerina VM implementation, we are currently left will .bal and .balx. This PR removes changes related .bsz .bmz and introduces running .balx inside containers. 